### PR TITLE
Fix stored XSS in HTML report; add geocoding privacy controls & positional CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ It has no Python dependencies beyond exiftool. One `curl` and you're operational
 
 **What it does beyond extraction:**
 - Direct web scraping of target sites (no search engine dependency, no IP blocks)
-- GPS reverse geocoding with OpenStreetMap, map link generation
+- GPS reverse geocoding with OpenStreetMap (opt-out with `--no-geocode`), map link generation
 - Export to HTML, TXT, or JSON
 - Selective field extraction with `--parse-only`
 - Deduplication across multiple files
@@ -126,6 +126,26 @@ docker run --rm -v $(pwd)/loot:/data franckferman/metadetective -d /data
 ---
 
 ## Usage
+
+### Quick start (positional shortcut)
+
+MetaDetective auto-detects a positional argument: a **path** runs analysis, an **http(s):// URL** runs scraping. The classic `-d` / `-s -u` flags still work exactly as before.
+
+```bash
+# Analyze a directory
+python3 MetaDetective.py ./loot/
+
+# Analyze a single file
+python3 MetaDetective.py report.pdf
+
+# Scrape a website (preview only)
+python3 MetaDetective.py https://target.com/ --scan
+
+# Scrape and download (defaults to ./loot/ and --depth 1)
+python3 MetaDetective.py https://target.com/
+```
+
+Safeguards are preserved: a path never triggers web scraping, and a URL rejects analysis-only flags.
 
 ### File analysis
 
@@ -222,14 +242,14 @@ MetaDetective can crawl a target website, discover downloadable files (PDF, DOCX
 - **`--download-dir`** - Download files to a local directory for analysis. This is the primary mode.
 - **`--scan`** - Preview only: list discovered files and stats without downloading. Useful for scoping before a full download.
 
-> `--scan` and `--download-dir` are mutually exclusive.
+> `--scan` and `--download-dir` are mutually exclusive. If neither is given, MetaDetective defaults to **download** mode into `./loot/` (created if missing).
 
-**The `--depth` flag is critical.** By default, depth is **0**: MetaDetective only looks at the URL you provide. Most interesting files (reports, presentations, internal documents) are linked from subpages, not the homepage. **Always set `--depth 1` or higher for real engagements.**
+**The `--depth` flag controls crawl breadth.** The default is **1**: MetaDetective looks at the target URL *and* the pages linked from it, which covers most site structures. Use `0` to restrict to the single target page, or `2+` for deeper crawls.
 
 | Depth | Behavior |
 |-------|----------|
-| `0` (default) | Only the target URL. Finds files directly linked on that single page. |
-| `1` | Target URL + all pages linked from it. Covers most site structures. |
+| `0` | Only the target URL. Finds files directly linked on that single page. |
+| `1` (default) | Target URL + all pages linked from it. Covers most site structures. |
 | `2+` | Follows links N levels deep. Broader coverage, more requests, slower. |
 
 **Download (primary workflow):**
@@ -281,9 +301,9 @@ python3 MetaDetective.py -d ~/loot/ -e html -o ~/results/
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--url` | required | Target URL |
-| `--download-dir` | - | Download destination (created if needed) |
+| `--download-dir` | `./loot/` | Download destination (created if missing). Used by default when neither `--scan` nor `--download-dir` is set. |
 | `--scan` | - | Preview mode (no download) |
-| `--depth` | `0` | Link depth to follow. **Set to 1+ for real use.** |
+| `--depth` | `1` | Link depth to follow. Use `0` for the single page, `2+` for deeper crawls. |
 | `--extensions` | all supported | Filter by file type |
 | `--threads` | `4` | Concurrent download threads (1-100) |
 | `--rate` | `5` | Max requests per second (1-1000) |
@@ -349,6 +369,8 @@ python3 MetaDetective.py -d ./loot/ -e json -c pentest-corp -o ~/results/
 
 The HTML export includes a summary header showing total files analyzed, total metadata fields extracted, and unique identities found (from Author, Creator, and Last Modified By fields).
 
+> All metadata values are HTML-escaped in the report. A document carrying crafted metadata (e.g. a malicious `Author` field) cannot inject markup or scripts into the report you open in your browser.
+
 ### User-Agent (scraping)
 
 When scraping, MetaDetective identifies itself as `MetaDetective/<version>` by default. Use `--user-agent` to change this:
@@ -366,6 +388,23 @@ python3 MetaDetective.py --scraping --scan --url https://target.com/ --user-agen
 python3 MetaDetective.py --scraping --scan --url https://target.com/ \
   --user-agent 'Mozilla/5.0 (compatible; MyScanner/1.0)'
 ```
+
+### Reverse geocoding and privacy
+
+When a file exposes GPS coordinates, MetaDetective resolves them to a human-readable address via OpenStreetMap's Nominatim service. **This sends the target's coordinates to a third party.** Requests are rate-limited to 1/second (per Nominatim's usage policy) and cached.
+
+```bash
+# Opsec: disable geocoding entirely, show raw GPS only, no third-party request
+python3 MetaDetective.py -d ./loot/ --no-geocode
+
+# Query your own (self-hosted) Nominatim server instead of the public one
+python3 MetaDetective.py -d ./loot/ --nominatim-url https://nominatim.example.com
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--no-geocode` | off (geocoding on) | Disable reverse geocoding; no coordinates leave your machine |
+| `--nominatim-url` | public OSM server | Base URL of a Nominatim server to query |
 
 ### Filtering
 

--- a/TODO.md
+++ b/TODO.md
@@ -42,6 +42,43 @@
   - [ ] Implement local filtering based on sections like "Author" and "Last Modified By".
     - [ ] Add --filter-field to filter entire file entries by field value (distinct from --ignore which filters values, and --parse-only which filters fields).
 
+### Security (report hardening)
+
+- [X] ~~**Escape all metadata values in the HTML export (stored-XSS fix)**~~
+  - [X] ~~HTML-escape every metadata value/field; build Address/Map Link with escaped text and encoded URLs.~~
+  - [X] ~~Add regression tests with `<img onerror>` / `<script>` payloads.~~
+  - [ ] Add a Content-Security-Policy `<meta>` to the report as defense-in-depth.
+
+### Geolocation / privacy
+
+- [X] ~~**Opt-out and self-hosting for reverse geocoding**~~
+  - [X] ~~Add `--no-geocode` (no coordinates sent to any third party).~~
+  - [X] ~~Add `--nominatim-url` for a custom/self-hosted Nominatim server.~~
+  - [X] ~~Enforce Nominatim's ≤1 req/s usage policy (shared rate limiter).~~
+  - [ ] Offline reverse geocoding (bundled/local dataset) for full opsec, no network.
+
+### CLI usability
+
+- [X] ~~**Positional target auto-detection**~~
+  - [X] ~~`MetaDetective.py <dir|file>` for analysis, `MetaDetective.py <url>` for scraping (with safeguards).~~
+  - [X] ~~Default `--download-dir` to ./loot/ and `--depth` to 1.~~
+
+### Metadata extraction robustness
+
+- [ ] **Use exiftool structured JSON output**
+  - [ ] Replace per-file `exiftool <file>` + line parsing with `exiftool -j -G` (structured, locale-proof, handles values containing ':').
+  - [ ] Batch multiple files / a directory in a single exiftool call (or `-stay_open`) for a large speed-up on big dumps.
+
+### Scraper hardening (OSINT-grade)
+
+- [ ] **Proxy / anonymity**
+  - [ ] Add `--proxy` support including SOCKS5/Tor (route requests, avoid burning the source IP).
+- [ ] **Resilience**
+  - [ ] Retry with exponential backoff + jitter; honor HTTP `Retry-After`.
+- [ ] **Politeness**
+  - [ ] Optional `--respect-robots` (robots.txt), off by default for authorized testing.
+  - [ ] Per-domain concurrency cap.
+
 ### Testing
 
 - [ ] **Expand unit test coverage**

--- a/src/MetaDetective/MetaDetective.py
+++ b/src/MetaDetective/MetaDetective.py
@@ -73,6 +73,8 @@ EXIFTOOL_NOT_INSTALLED = "Error: exiftool is not installed. Please install it to
 EXIFTOOL_EXECUTION_ERROR = "Error: exiftool encountered an error."
 
 NOMINATIM_HOST = "nominatim.openstreetmap.org"
+NOMINATIM_SCHEME = "https"
+GEOCODE_ENABLED = True
 USER_AGENT = f'MetaDetective/{__version__}'
 
 UA_PRESETS = {
@@ -99,6 +101,8 @@ DEFAULT_WORKER_TIMEOUT = 1.0
 DEFAULT_SHUTDOWN_TIMEOUT = 5.0
 DEFAULT_RATE_LIMIT = 5
 DEFAULT_NUM_THREADS = 4
+DEFAULT_DEPTH = 1
+DEFAULT_DOWNLOAD_DIR = "loot"
 MAX_FILENAME_LENGTH = 16
 MAX_RETRIES = 3
 
@@ -516,6 +520,8 @@ class AddressResolver:
     # Class-level cache to avoid repeated requests for same coordinates
     _cache: Dict[Tuple[str, str], str] = {}
     _cache_lock = threading.Lock()
+    # Nominatim usage policy: at most 1 request per second, shared across threads
+    _rate_limiter = RateLimiter(1.0)
 
     @classmethod
     def get_address_from_coords(cls, lat: str, lon: str, timeout: int = DEFAULT_HTTP_TIMEOUT) -> str:
@@ -531,6 +537,9 @@ class AddressResolver:
         Returns:
             Address as a string, or empty string if error
         """
+        if not GEOCODE_ENABLED:
+            return ""
+
         try:
             lat_float = float(lat)
             lon_float = float(lon)
@@ -548,7 +557,11 @@ class AddressResolver:
                 return cls._cache[cache_key]
 
         try:
-            conn = http.client.HTTPSConnection(NOMINATIM_HOST, timeout=timeout)
+            cls._rate_limiter.wait()
+            if NOMINATIM_SCHEME == "http":
+                conn = http.client.HTTPConnection(NOMINATIM_HOST, timeout=timeout)
+            else:
+                conn = http.client.HTTPSConnection(NOMINATIM_HOST, timeout=timeout)
             headers = {'User-Agent': USER_AGENT}
             endpoint = NOMINATIM_ENDPOINT.format(lat=lat_normalized, lon=lon_normalized)
             conn.request("GET", endpoint, headers=headers)
@@ -1701,6 +1714,64 @@ def valid_url(url: str) -> str:
     return url
 
 
+def looks_like_url(value: str) -> bool:
+    """
+    Return True if the value looks like an http(s) URL.
+
+    Args:
+        value: The string to test
+
+    Returns:
+        True if the value starts with http:// or https://
+    """
+    return bool(re.match(r'^https?://', value, re.IGNORECASE))
+
+
+def resolve_positional_target(parser: argparse.ArgumentParser, args: Namespace) -> None:
+    """
+    Resolve the positional TARGET into an explicit mode.
+
+    A http(s):// URL enables scraping mode; an existing directory or file
+    enables analysis mode. Incompatible combinations raise a parser error so
+    that safeguards (no web scan on a local path, no analysis flags on a URL)
+    are preserved.
+
+    Args:
+        parser: The argument parser, used for consistent error reporting
+        args: Parsed arguments (modified in-place)
+    """
+    target = args.target
+
+    if looks_like_url(target):
+        if args.directory or args.files or args.type != ['all'] or args.ignore:
+            parser.error(
+                "A URL target enables scraping mode and cannot be combined with analysis "
+                "options (-d/--directory, -f/--files, -t/--type, -i/--ignore)."
+            )
+        if args.url and args.url != target:
+            parser.error("Conflicting URLs provided as positional target and --url.")
+        try:
+            valid_url(target)
+        except argparse.ArgumentTypeError as exc:
+            parser.error(str(exc))
+        args.scraping = True
+        args.url = target
+    else:
+        if args.scraping or args.url or args.scan or args.download_dir:
+            parser.error(
+                "A directory/file target enables analysis mode and cannot be combined with "
+                "scraping options (-s/--scraping, -u/--url, --scan, --download-dir)."
+            )
+        if args.directory or args.files:
+            parser.error("Do not combine a positional target with -d/--directory or -f/--files.")
+        if os.path.isdir(target):
+            args.directory = target
+        elif os.path.isfile(target):
+            args.files = [target]
+        else:
+            parser.error(f"Target '{target}' is not a URL, an existing directory, or an existing file.")
+
+
 # ============================================================================
 # Main Functions
 # ============================================================================
@@ -1840,6 +1911,11 @@ def main():
     parser = argparse.ArgumentParser(
         description="Retrieve and display metadata from files using exiftool.",
         epilog="Example commands:\n\n"
+               "# Quick shortcuts (positional target, auto-detected):\n"
+               "python3 MetaDetective.py ./loot/                      # analyze a directory\n"
+               "python3 MetaDetective.py report.pdf                   # analyze a single file\n"
+               "python3 MetaDetective.py https://target.com/ --scan   # scrape a site\n"
+               "\n"
                "# Analysis:\n"
                "   # Analyze metadata in a specified directory:\n"
                "python3 MetaDetective.py -d path/to/directory\n"
@@ -1861,13 +1937,20 @@ def main():
         formatter_class=argparse.RawTextHelpFormatter
     )
 
+    parser.add_argument(
+        'target', nargs='?', metavar='TARGET',
+        help="Positional shortcut, auto-detected:\n"
+             "  - a directory or file  -> analysis mode (like -d / -f)\n"
+             "  - an http(s):// URL    -> scraping mode (like -s -u)"
+    )
+
     scraping_group = parser.add_argument_group('scraping options', 'Options for scraping files containing potential metadata from a website.')
     scraping_group.add_argument('-s', '--scraping', action='store_true', help="Argument required to activate scraping mode.")
     scraping_group.add_argument('-u', "--url", type=valid_url, help="Site url for scraping.")
     scraping_group.add_argument("--scan", action="store_true", help="Scans the website and displays information and statistics without downloading files.")
     scraping_group.add_argument('--extensions', nargs='+', type=str.lower, help='File extensions to filter by, e.g., --extensions pdf jpg png')
-    scraping_group.add_argument("--depth", type=int, default=0, help="Depth of links to follow on the site.")
-    scraping_group.add_argument("--download-dir", type=valid_directory, help="Directory where files that have been scraped should be stored.")
+    scraping_group.add_argument("--depth", type=int, default=DEFAULT_DEPTH, help=f"Depth of links to follow on the site (default: {DEFAULT_DEPTH}).")
+    scraping_group.add_argument("--download-dir", type=valid_output_directory, help=f"Directory to store scraped files (created if missing). Defaults to ./{DEFAULT_DOWNLOAD_DIR}/ when neither --scan nor --download-dir is given.")
     scraping_group.add_argument("--follow-extern", action="store_true", help="Follow external links.")
     scraping_group.add_argument("--threads", type=int, default=DEFAULT_NUM_THREADS, help="Number of threads to use (1-100).")
     scraping_group.add_argument("--rate", type=int, default=DEFAULT_RATE_LIMIT, help="Maximum number of requests per second (0.1-1000).")
@@ -1892,6 +1975,8 @@ def main():
     display_group.add_argument('--summary', action='store_true', help="Show a statistical summary: file count, unique identities, emails, GPS exposure, tools, date range.")
     display_group.add_argument('--timeline', action='store_true', help="Display a chronological timeline of document creation and modification events.")
     display_group.add_argument('--no-banner', action='store_true', help="Suppress the ASCII banner. Useful for scripting and pipeline integration.")
+    display_group.add_argument('--no-geocode', action='store_true', help="Disable GPS reverse geocoding. No coordinates are sent to Nominatim/OpenStreetMap; raw GPS values are still shown.")
+    display_group.add_argument('--nominatim-url', metavar='URL', help="Base URL of a Nominatim reverse-geocoding server (e.g. https://nominatim.example.com). Default: public OpenStreetMap server.")
 
     export_group = parser.add_argument_group('export options', 'Options for exporting results.')
     export_group.add_argument('-e', '--export', nargs='?', const='html', choices=['html', 'txt', 'json'], default=None, help="Export results. Default format is HTML. Text (txt) and JSON (json) exports are also possible.")
@@ -1904,14 +1989,35 @@ def main():
         parser.print_help()
         sys.exit(0)
 
+    # Resolve the positional TARGET (URL -> scraping, directory/file -> analysis).
+    if args.target is not None:
+        resolve_positional_target(parser, args)
+
+    # Reverse-geocoding configuration (analysis / export only).
+    global GEOCODE_ENABLED, NOMINATIM_HOST, NOMINATIM_SCHEME
+    if args.no_geocode:
+        GEOCODE_ENABLED = False
+    if args.nominatim_url:
+        parsed_nominatim = urlparse(args.nominatim_url)
+        if parsed_nominatim.scheme not in ('http', 'https') or not parsed_nominatim.netloc:
+            parser.error("--nominatim-url must be a full http(s):// URL, e.g. https://nominatim.example.com")
+        NOMINATIM_SCHEME = parsed_nominatim.scheme
+        NOMINATIM_HOST = parsed_nominatim.netloc
+
     if args.scraping:
         if args.directory or args.files or args.ignore:
             parser.error("Analysis arguments (--directory/-d, --files/-f, and --ignore/-i) cannot be used with scrapping options (--scraping/-s).")
 
         if args.scan and args.download_dir:
-            parser.error("The scan (--scan) and download (--download-dir) arguments cannot be specified together. Choose between one or the other mode in scraping mode, but not both.")
+            parser.error("The scan (--scan) and download (--download-dir) arguments cannot be specified together. Choose one or the other in scraping mode, but not both.")
         elif not args.scan and not args.download_dir:
-            parser.error("You must choose at least between the scan (--scan) or download (--download-dir) argument in scraping mode.")
+            # No mode chosen: default to download mode into ./loot/ (created if missing).
+            try:
+                args.download_dir = valid_output_directory(DEFAULT_DOWNLOAD_DIR)
+            except argparse.ArgumentTypeError as exc:
+                parser.error(str(exc))
+            if '--no-banner' not in sys.argv:
+                print(f"[*] No --scan/--download-dir given: downloading to default './{DEFAULT_DOWNLOAD_DIR}/'.")
 
         if not args.url:
             parser.error("The url choice argument (-u or --url) is required for scraping mode.")
@@ -1973,6 +2079,9 @@ def main():
             parser.error("The directory (--directory/-d) and files (--files/-f) arguments cannot be specified together. Choose between one or the other mode in analysis mode, but not both.")
 
         ignore_patterns = args.ignore if args.ignore else []
+
+        if args.no_geocode and '--no-banner' not in sys.argv:
+            print("[*] Reverse geocoding disabled (--no-geocode): GPS coordinates are not sent to Nominatim.")
 
         if args.display == 'all' and args.format:
             parser.error("The formatting (--format) argument is not compatible with the 'all' display mode (--display all).")

--- a/src/MetaDetective/MetaDetective.py
+++ b/src/MetaDetective/MetaDetective.py
@@ -10,6 +10,7 @@ Refactored  : Enhanced multithreading and code structure
 
 import argparse
 import datetime
+import html
 import http.client
 import json
 import os
@@ -1210,6 +1211,61 @@ class MetadataExporter:
     """Handles metadata export operations."""
 
     @staticmethod
+    def _safe_gps_links(lat: str, lon: str, address: str) -> Dict[str, str]:
+        """
+        Build HTML-safe anchor tags for the 'Address' and 'Map Link' fields.
+
+        Text nodes are HTML-escaped and URLs are percent-encoded so that
+        attacker-controlled metadata (e.g. a crafted Nominatim display_name)
+        cannot inject markup into the report.
+
+        Args:
+            lat: Latitude (already formatted by MetaDetective)
+            lon: Longitude (already formatted by MetaDetective)
+            address: Resolved address text (may be empty)
+
+        Returns:
+            Mapping of field name -> safe HTML snippet
+        """
+        links: Dict[str, str] = {}
+        lat_q = quote(str(lat), safe="")
+        lon_q = quote(str(lon), safe="")
+        map_url = f"https://nominatim.openstreetmap.org/ui/reverse.html?lat={lat_q}&lon={lon_q}"
+        links["Map Link"] = (
+            f'<a href="{html.escape(map_url, quote=True)}" target="_blank" '
+            f'rel="noopener noreferrer">View on Map</a>'
+        )
+        if address:
+            search_url = NOMINATIM_SEARCH_URL + quote(address, safe="")
+            links["Address"] = (
+                f'<a href="{html.escape(search_url, quote=True)}" target="_blank" '
+                f'rel="noopener noreferrer">{html.escape(address)}</a>'
+            )
+        return links
+
+    @staticmethod
+    def _render_singular_value(field: str, value: str) -> str:
+        """
+        Render a single (unique) metadata value as safe HTML.
+
+        Every value is HTML-escaped. 'Map Link' values hold a plain URL and are
+        wrapped in a safe anchor.
+
+        Args:
+            field: Metadata field name
+            value: Value to render
+
+        Returns:
+            Safe HTML snippet
+        """
+        if field == "Map Link":
+            return (
+                f'<a href="{html.escape(value, quote=True)}" target="_blank" '
+                f'rel="noopener noreferrer">View on Map</a>'
+            )
+        return html.escape(value)
+
+    @staticmethod
     def export_metadata_to_html(
         args: Namespace,
         all_metadata: List[Dict[str, str]],
@@ -1264,23 +1320,27 @@ class MetadataExporter:
             for metadata in all_metadata:
                 html_parts.append('<div class="metadata-entry">')
 
+                gps_html: Dict[str, str] = {}
                 formatted_gps = metadata.get("Formatted GPS Position")
                 if formatted_gps:
                     try:
                         lat, lon = formatted_gps.split(", ")
                         address = AddressResolver.get_address_from_coords(lat, lon)
                         if address:
-                            encoded_address = quote(address)
-                            link_to_address = f"{NOMINATIM_SEARCH_URL}{encoded_address}"
-                            metadata["Address"] = f"<a href='{link_to_address}' target='_blank' rel='noopener noreferrer'>{address}</a>"
-                        metadata["Map Link"] = f"<a href='https://nominatim.openstreetmap.org/ui/reverse.html?lat={lat}&lon={lon}' target='_blank' rel='noopener noreferrer'>View on Map</a>"
+                            metadata["Address"] = address
+                        metadata["Map Link"] = "View on Map"
+                        gps_html = MetadataExporter._safe_gps_links(lat, lon, address)
                     except ValueError:
                         pass
 
                 displayed_fields = 0
                 for field, value in metadata.items():
                     if field in FIELDS and value and not PatternMatcher.matches_any_pattern(value, ignore_patterns):
-                        html_parts.append(f'<div class="field-row"><span class="field-key">{field}</span><span class="field-val">{value}</span></div>')
+                        rendered = gps_html.get(field, html.escape(value))
+                        html_parts.append(
+                            f'<div class="field-row"><span class="field-key">{html.escape(field)}</span>'
+                            f'<span class="field-val">{rendered}</span></div>'
+                        )
                         displayed_fields += 1
 
                 if displayed_fields == 0:
@@ -1295,13 +1355,10 @@ class MetadataExporter:
                 if formatted_gps:
                     try:
                         lat, lon = formatted_gps.split(", ")
-                        address = AddressResolver.get_address_from_coords(lat, lon)
-                        if address:
-                            encoded_address = quote(address)
-                            link_to_address = f"{NOMINATIM_SEARCH_URL}{encoded_address}"
-                            metadata["Address"] = f"<a href='{link_to_address}' target='_blank' rel='noopener noreferrer'>{address}</a>"
-                        map_link = f"https://nominatim.openstreetmap.org/ui/reverse.html?lat={lat}&lon={lon}"
-                        metadata["Map Link"] = f"<a href='{map_link}' target='_blank' rel='noopener noreferrer'>View on Map</a>"
+                        # 'Address' is not part of UNIQUE_FIELDS, so it is never
+                        # displayed in singular mode: skip the Nominatim lookup
+                        # entirely (no wasted request, no coordinate leak).
+                        metadata["Map Link"] = NOMINATIM_LINK.format(lat=lat, lon=lon)
                     except ValueError:
                         pass
 
@@ -1324,14 +1381,18 @@ class MetadataExporter:
                     for value in values
                 }.keys()
                 if unique_cased_values:
-                    html_parts.append(f'<h3>{field}</h3>')
+                    html_parts.append(f'<h3>{html.escape(field)}</h3>')
                     if args.format == 'formatted':
                         html_parts.append('<ul>')
                         for unique_value in unique_cased_values:
-                            html_parts.append(f'<li>{unique_value}</li>')
+                            html_parts.append(f'<li>{MetadataExporter._render_singular_value(field, unique_value)}</li>')
                         html_parts.append('</ul>')
                     else:
-                        html_parts.append(f"<p>{', '.join(unique_cased_values)}</p>")
+                        rendered = ', '.join(
+                            MetadataExporter._render_singular_value(field, v)
+                            for v in unique_cased_values
+                        )
+                        html_parts.append(f"<p>{rendered}</p>")
 
         html_parts.append(f'<div class="footer">MetaDetective {__version__}</div>')
         html_parts.append('</div></body></html>')

--- a/tests/test_MetaDetective.py
+++ b/tests/test_MetaDetective.py
@@ -405,5 +405,58 @@ class TestPatternMatcher(unittest.TestCase):
         self.assertFalse(md.PatternMatcher.matches_any_pattern("anything", []))
 
 
+# ============================================================================
+# HTML export escaping (stored-XSS regression)
+# ============================================================================
+
+class TestHtmlExportEscaping(unittest.TestCase):
+    """Ensure attacker-controlled metadata cannot inject markup into the report."""
+
+    IMG_PAYLOAD = '<img src=x onerror="alert(1)">'
+    SCRIPT_PAYLOAD = "<script>alert(document.domain)</script>"
+
+    def _malicious_metadata(self):
+        return {
+            "File Name": "piege.pdf",
+            "Author": self.IMG_PAYLOAD,
+            "Creator": f"Normal {self.SCRIPT_PAYLOAD} Corp",
+            "Title": self.SCRIPT_PAYLOAD,
+        }
+
+    def test_display_all_escapes_payloads(self):
+        args = argparse.Namespace(display="all", format=None)
+        html = md.MetadataExporter.export_metadata_to_html(
+            args, [self._malicious_metadata()], []
+        )
+        self.assertNotIn(self.IMG_PAYLOAD, html)
+        self.assertNotIn(self.SCRIPT_PAYLOAD, html)
+        # The escaped form must be present instead
+        self.assertIn("&lt;img src=x onerror", html)
+        self.assertIn("&lt;script&gt;", html)
+
+    def test_display_singular_escapes_payloads(self):
+        args = argparse.Namespace(display="singular", format="concise")
+        html = md.MetadataExporter.export_metadata_to_html(
+            args, [self._malicious_metadata()], []
+        )
+        self.assertNotIn(self.IMG_PAYLOAD, html)
+        self.assertIn("&lt;img src=x onerror", html)
+
+    def test_map_link_still_rendered_as_anchor(self):
+        # 'Map Link' holds a plain URL and must remain a working anchor.
+        rendered = md.MetadataExporter._render_singular_value(
+            "Map Link", "https://nominatim.openstreetmap.org/ui/reverse.html?lat=1&lon=2"
+        )
+        self.assertIn('<a href="https://nominatim.openstreetmap.org', rendered)
+        self.assertIn("View on Map", rendered)
+
+    def test_safe_gps_links_escapes_address(self):
+        links = md.MetadataExporter._safe_gps_links(
+            "1.0", "2.0", '<img src=x onerror=alert(1)>'
+        )
+        self.assertNotIn("<img src=x onerror", links["Address"])
+        self.assertIn("&lt;img", links["Address"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_MetaDetective.py
+++ b/tests/test_MetaDetective.py
@@ -458,5 +458,38 @@ class TestHtmlExportEscaping(unittest.TestCase):
         self.assertIn("&lt;img", links["Address"])
 
 
+# ============================================================================
+# Geocoding opt-out and URL auto-detection
+# ============================================================================
+
+class TestGeocodeOptOut(unittest.TestCase):
+
+    def test_no_geocode_short_circuits_network(self):
+        original = md.GEOCODE_ENABLED
+        try:
+            md.GEOCODE_ENABLED = False
+            with patch("src.MetaDetective.MetaDetective.http.client.HTTPSConnection") as mock_conn:
+                result = md.AddressResolver.get_address_from_coords("47.0", "10.0")
+                self.assertEqual(result, "")
+                mock_conn.assert_not_called()
+        finally:
+            md.GEOCODE_ENABLED = original
+            md.AddressResolver.clear_cache()
+
+
+class TestLooksLikeUrl(unittest.TestCase):
+
+    def test_http_and_https_are_urls(self):
+        self.assertTrue(md.looks_like_url("http://example.com"))
+        self.assertTrue(md.looks_like_url("https://example.com/x"))
+        self.assertTrue(md.looks_like_url("HTTPS://EXAMPLE.COM"))
+
+    def test_paths_are_not_urls(self):
+        self.assertFalse(md.looks_like_url("./loot"))
+        self.assertFalse(md.looks_like_url("/home/user/docs"))
+        self.assertFalse(md.looks_like_url("report.pdf"))
+        self.assertFalse(md.looks_like_url("ftp://example.com/f"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

This branch hardens the HTML report and adds privacy/UX controls that came out of a security review of the export and analysis paths.

### 1. Security — stored XSS in the HTML report (fix)
File metadata (`Author`, `Title`, `Creator`, …) is attacker-controlled and was written into the HTML report **unescaped**. A crafted document could run JavaScript in the analyst's browser when the report is opened. Proven with an `<img onerror>` / `<script>` payload, now fixed: all values and field names are HTML-escaped, and the Address / Map Link anchors are rebuilt with escaped text and percent-encoded URLs. Regression tests added for both display modes.

### 2. Geocoding privacy
- `--no-geocode`: disable reverse geocoding (no coordinates sent to any third party; raw GPS still shown).
- `--nominatim-url`: query a self-hosted Nominatim server instead of the public one.
- Enforce Nominatim's **1 req/s** usage policy; drop the unused reverse lookup in singular mode (no wasted request, no coordinate leak).

### 3. CLI ergonomics
- Positional `TARGET` auto-detection: a path → analysis, an `http(s)` URL → scraping. `-d` / `-s -u` still work; incompatible combinations are rejected so the existing safeguards are preserved.
- Defaults: `--download-dir` → `./loot/` (created if missing), `--depth` → `1`.

### Behaviour changes to note
- `--depth` default **0 → 1** (matches the README's long-standing advice).
- Scraping with neither `--scan` nor `--download-dir` now downloads to `./loot/` instead of erroring.
- `--download-dir` is created if missing.

### Testing
- 57 unit tests pass locally (50 existing + 7 new).
- `py_compile` clean; functional end-to-end checks (HTML export escaping, positional dir/file/URL, safeguards) verified manually.

Docs (README + TODO) updated accordingly.