### PR TITLE
docs(site): exiftool one-liner note (restore green Pages check)

### DIFF
--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -769,7 +769,7 @@
           <span class="faq-q-icon">&#9658;</span>
         </button>
         <div class="faq-a"><div class="faq-a-inner">
-          In the field, you don't always have pip access or internet connectivity. A single <span class="hi">.py</span> file means one <span class="hi">curl</span> command and you're operational. The only dependency is exiftool, which ships with Kali and most security distributions. This is a deliberate design choice.
+          In the field, you don't always have pip access or internet connectivity. A single <span class="hi">.py</span> file means one <span class="hi">curl</span> command and you're operational. The only dependency is exiftool - preinstalled on Kali and one package away everywhere else (<span class="hi">apt</span>, <span class="hi">pacman</span>, <span class="hi">emerge</span>, <span class="hi">brew</span>, <span class="hi">winget</span>). This is a deliberate design choice.
         </div></div>
       </div>
 


### PR DESCRIPTION
Small doc improvement complementing the new install section (exiftool is one package away on apt/pacman/emerge/brew/winget). Also produces a fresh push-triggered Pages deploy so the branch shows a green check again.