### PR TITLE
docs(site): rename Exhibit H to Tunable Crawler

### DIFF
--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -561,10 +561,9 @@
         <div class="exhibit-tag">
           <div class="exhibit-num">08</div>
           <span class="exhibit-label">Exhibit H</span>
-          <span class="new-tag">new</span>
         </div>
-        <h3 class="exhibit-title">Stealth Scraping</h3>
-        <p class="exhibit-desc"><span class="hi">--user-agent stealth</span> swaps the default UA for a realistic browser fingerprint. 13 presets: Chrome, Firefox, Safari, Edge, Android, iPhone, Googlebot. Or pass any custom string.</p>
+        <h3 class="exhibit-title">Tunable Crawler</h3>
+        <p class="exhibit-desc">You set the pace: requests/second (<span class="hi">--rate</span>), <span class="hi">--threads</span>, crawl <span class="hi">--depth</span>, <span class="hi">--extensions</span> filters, <span class="hi">--follow-extern</span>, and a browser-realistic <span class="hi">--user-agent</span> (13 presets or your own).</p>
       </div>
 
       <div class="exhibit">


### PR DESCRIPTION
Reframe 'Stealth Scraping' -> 'Tunable Crawler' (honest: real stealth/proxy is still a TODO). Keeps the UA presets, surfaces the actual crawler controls. Drops the 'new' badge.