### PR TITLE
docs: 'try it live' scraping example (practice lab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,15 @@ jq '.unique.Author' MetaDetective_Export-*.json
 
 MetaDetective can crawl a target website, discover downloadable files (PDF, DOCX, XLSX, images, etc.), and download them for local metadata analysis.
 
+**Try it live** — this project's own site hosts a hidden practice lab (metadata-rich sample documents). Point MetaDetective at it and analyze what comes back:
+
+```bash
+python3 MetaDetective.py https://franckferman.github.io/MetaDetective/
+python3 MetaDetective.py ./loot/ --summary
+```
+
+You'll recover planted identities, emails, tools, and GPS coordinates. (Keep the trailing slash, or use a version >= the post-2.0.6 fix that follows the redirect.)
+
 **Two scraping modes:**
 
 - **`--download-dir`** - Download files to a local directory for analysis. This is the primary mode.

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -717,6 +717,20 @@
         </div>
       </div>
 
+      <div class="protocol-card">
+        <div class="protocol-head">
+          <span class="dot dot-r"></span><span class="dot dot-y"></span><span class="dot dot-g"></span>
+          <span class="protocol-title">protocol_05 :: try it live</span>
+        </div>
+        <div class="protocol-body">
+<pre><span class="cm"># Scrape this very site - it hides a practice lab</span>
+<span class="cp">$ </span><span class="cc">python3 MetaDetective.py</span> <span class="cv">https://franckferman.github.io/MetaDetective/</span>
+
+<span class="cm"># Analyze what you recovered (identities, emails, GPS...)</span>
+<span class="cp">$ </span><span class="cc">python3 MetaDetective.py</span> <span class="cv">./loot/</span> <span class="cf">--summary</span></pre>
+        </div>
+      </div>
+
     </div>
   </div>
 </section>


### PR DESCRIPTION
Adds a visible example that scrapes this project's own site (hidden practice lab) and analyzes the loot, in the README and a new website protocol card. Encourages users to try the scrape -> --summary flow end-to-end.